### PR TITLE
QUO-2221 Include user api key into resource attr

### DIFF
--- a/quotientai/_constants.py
+++ b/quotientai/_constants.py
@@ -1,3 +1,5 @@
 TRACER_NAME = "quotient.sdk.python"
 DEFAULT_TRACING_ENDPOINT = "https://otel.quotientai.co/v1/traces"
+# DEFAULT_TRACING_ENDPOINT = "http://localhost:4318/v1/traces"
+
 


### PR DESCRIPTION
Api key is passed into the traces, so control plane can identify what user the trace belongs to 