### PR TITLE
Update typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-typer = "^0.9.0"
+typer = ">=0.16.0"
 rich = "^13.7.0"
 click = "^8.1.7"
 httpx = ">=0.27.0"
@@ -42,5 +42,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 quotient = "quotientai.cli.entrypoint:app"
+
 
 


### PR DESCRIPTION
Fix typer version conflict with mcp[cli] dependency, mcp[cli]==1.12.3 requires typer >=0.16.0 but all quotientai versions require typer >=0.9.0, <0.10.0.